### PR TITLE
RobotCommand Dribbler: bool -> int

### DIFF
--- a/proto/RobotCommand.proto
+++ b/proto/RobotCommand.proto
@@ -9,7 +9,7 @@ message RobotCommand {
     Vector2f vel = 3;
     float w = 4;
     bool use_angle = 5;
-    bool dribbler = 6;
+    int dribbler = 6;
 
     bool kicker = 7;
     bool chipper = 8;


### PR DESCRIPTION
Based on the issue: proto packet definition "dribbler" of "robot command" might be incorrect #691 in roboteam_ai repository