### PR TITLE
publish/subscribe over the network by setting custom ip addresses

### DIFF
--- a/include/roboteam_proto/Channel.h
+++ b/include/roboteam_proto/Channel.h
@@ -14,6 +14,7 @@ struct Channel {
   Channel(std::string name, std::string ip, std::string port);
   Channel(const Channel & other);
 
+  std::string getAddress(const std::string & _ip, const std::string & _port);
   std::string getSubscribeAddress();
   std::string getPublishAddress();
 

--- a/include/roboteam_proto/Channel.h
+++ b/include/roboteam_proto/Channel.h
@@ -7,11 +7,15 @@ namespace proto {
 
 struct Channel {
   std::string name;
+  std::string ip;
   std::string port;
 
   Channel() =default;
-  Channel(std::string name, std::string port);
+  Channel(std::string name, std::string ip, std::string port);
   Channel(const Channel & other);
+
+  std::string getSubscribeAddress();
+  std::string getPublishAddress();
 
   bool operator == (const Channel & other);
   bool operator != (const Channel & other);

--- a/include/roboteam_proto/Publisher.h
+++ b/include/roboteam_proto/Publisher.h
@@ -41,16 +41,16 @@ class Publisher {
    */
   explicit Publisher(const ChannelType & channelType)
         : channel (CHANNELS.at(channelType)) {
-      std::cout << "[Roboteam_proto] Starting publisher for channel " << channel.name << std::endl;
+      std::cout << "[Roboteam_proto] Starting publisher for channel " << channel.getPublishAddress() << std::endl;
       socket = new zmqpp::socket(context, zmqpp::socket_type::pub);
-      socket->bind(channel.port);
+      socket->bind(channel.getPublishAddress());
   }
 
   /*
   * closes the socket before deleting the publisher
   */
   ~Publisher() {
-      std::cout << "[Roboteam_proto] Stopping publisher for channel " << channel.name << std::endl;
+      std::cout << "[Roboteam_proto] Stopping publisher for channel " << channel.getPublishAddress() << std::endl;
       socket->close();
       delete socket;
   }

--- a/include/roboteam_proto/Subscriber.h
+++ b/include/roboteam_proto/Subscriber.h
@@ -52,11 +52,11 @@ class Subscriber {
    */
   void init(const ChannelType & channelType) {
       this->channel = CHANNELS.at(channelType);
-      std::cout << "[Roboteam_proto] Starting subscriber for " << channel.name << std::endl;
+      std::cout << "[Roboteam_proto] Starting subscriber for " << channel.getSubscribeAddress() << std::endl;
     this->reactor = new zmqpp::reactor();
     this->socket = new zmqpp::socket(this->context, zmqpp::socket_type::sub);
     this->socket->subscribe("");
-    this->socket->connect(channel.port);
+    this->socket->connect(channel.getSubscribeAddress());
     running = true;
   }
 
@@ -129,7 +129,7 @@ class Subscriber {
    * Then we safely close the socket and delete the pointers.
    */
   ~Subscriber() {
-    std::cout << "[Roboteam_proto] Stopping subscriber for " << channel.name << std::endl;
+    std::cout << "[Roboteam_proto] Stopping subscriber for " << channel.getSubscribeAddress() << std::endl;
     running = false;
     t1.join();
     reactor->remove(*socket);

--- a/include/roboteam_proto/Subscriber.h
+++ b/include/roboteam_proto/Subscriber.h
@@ -136,7 +136,7 @@ class Subscriber {
    * Then we safely close the socket and delete the pointers.
    */
   ~Subscriber() {
-    std::cout << "[Roboteam_proto] Stopping subscriber for " << channel.getSubscribeAddress() << std::endl;
+    std::cout << "[Roboteam_proto] Stopping subscriber for " << channel.name << std::endl;
     running = false;
     t1.join();
     reactor->remove(*socket);

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -17,9 +17,13 @@ bool proto::Channel::operator!=(const proto::Channel &other) {
 }
 
 std::string proto::Channel::getSubscribeAddress() {
-    return "tcp://" + ip + ":" + port;
+    return getAddress(ip, port);
 }
 
 std::string proto::Channel::getPublishAddress() {
-    return "tcp://*:" + port;
+    return getAddress("*", port);
+}
+
+std::string proto::Channel::getAddress(const std::string & _ip, const std::string & _port) {
+    return "tcp://" + _ip + ":" + _port;
 }

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -1,11 +1,11 @@
 #include "Channel.h"
 
-proto::Channel::Channel(std::string name, std::string port)
-  : name(std::move(name)), port(std::move(port))
+proto::Channel::Channel(std::string name, std::string ip, std::string port)
+  : name(std::move(name)), ip(std::move(ip)), port(std::move(port))
   { }
 
 proto::Channel::Channel(const proto::Channel & other)
-  : name(other.name), port(other.port)
+  : name(other.name), port(other.port), ip(other.ip)
   { }
 
 bool proto::Channel::operator==(const proto::Channel &other) {
@@ -14,4 +14,12 @@ bool proto::Channel::operator==(const proto::Channel &other) {
 
 bool proto::Channel::operator!=(const proto::Channel &other) {
     return !(*this == other);
+}
+
+std::string proto::Channel::getSubscribeAddress() {
+    return "tcp://" + ip + ":" + port;
+}
+
+std::string proto::Channel::getPublishAddress() {
+    return "tcp://*:" + port;
 }

--- a/src/Channels.cpp
+++ b/src/Channels.cpp
@@ -4,15 +4,15 @@
 namespace proto {
 
 const std::map<ChannelType, Channel> CHANNELS = {
-    {GEOMETRY_CHANNEL, {"geometry", "192.168.1.33", "5556"}},
-    {REFEREE_CHANNEL, {"referee", "192.168.1.33", "5557"}},
-    {WORLD_CHANNEL, {"world", "192.168.1.33", "5558"}},
-    {ROBOT_COMMANDS_PRIMARY_CHANNEL, {"commands_primary", "192.168.1.33", "5559"}},
-    {ROBOT_COMMANDS_SECONDARY_CHANNEL, {"commands_secondary", "192.168.1.33", "5560"}},
-    {FEEDBACK_PRIMARY_CHANNEL, {"feedback_primary", "192.168.1.33", "5561"}},
-    {FEEDBACK_SECONDARY_CHANNEL, {"feedback_yellow", "192.168.1.33", "5562"}},
-    {SETTINGS_PRIMARY_CHANNEL, {"settings_primary", "192.168.1.33", "5563"}},
-    {SETTINGS_SECONDARY_CHANNEL, {"settings_secondary", "192.168.1.33", "5564"}}
+    {GEOMETRY_CHANNEL, {"geometry", "127.0.0.1", "5556"}},
+    {REFEREE_CHANNEL, {"referee", "127.0.0.1", "5557"}},
+    {WORLD_CHANNEL, {"world", "127.0.0.1", "5558"}},
+    {ROBOT_COMMANDS_PRIMARY_CHANNEL, {"commands_primary", "127.0.0.1", "5559"}},
+    {ROBOT_COMMANDS_SECONDARY_CHANNEL, {"commands_secondary", "127.0.0.1", "5560"}},
+    {FEEDBACK_PRIMARY_CHANNEL, {"feedback_primary", "127.0.0.1", "5561"}},
+    {FEEDBACK_SECONDARY_CHANNEL, {"feedback_yellow", "127.0.0.1", "5562"}},
+    {SETTINGS_PRIMARY_CHANNEL, {"settings_primary", "127.0.0.1", "5563"}},
+    {SETTINGS_SECONDARY_CHANNEL, {"settings_secondary", "127.0.0.1", "5564"}}
 };
 
 } // proto

--- a/src/Channels.cpp
+++ b/src/Channels.cpp
@@ -4,15 +4,15 @@
 namespace proto {
 
 const std::map<ChannelType, Channel> CHANNELS = {
-    {GEOMETRY_CHANNEL, {"geometry", "tcp://192.168.1.33:5556"}},
-    {REFEREE_CHANNEL, {"referee", "tcp://192.168.1.33:5557"}},
-    {WORLD_CHANNEL, {"world", "tcp://192.168.1.33:5558"}},
-    {ROBOT_COMMANDS_PRIMARY_CHANNEL, {"commands_primary", "tcp://192.168.1.33:5559"}},
-    {ROBOT_COMMANDS_SECONDARY_CHANNEL, {"commands_secondary", "tcp://192.168.1.33:5560"}},
-    {FEEDBACK_PRIMARY_CHANNEL, {"feedback_primary", "tcp://192.168.1.33:5561"}},
-    {FEEDBACK_SECONDARY_CHANNEL, {"feedback_yellow", "tcp://192.168.1.33:5562"}},
-    {SETTINGS_PRIMARY_CHANNEL, {"settings_primary", "tcp://192.168.1.33:5563"}},
-    {SETTINGS_SECONDARY_CHANNEL, {"settings_secondary", "tcp://192.168.1.33:5564"}}
+    {GEOMETRY_CHANNEL, {"geometry", "192.168.1.33", "5556"}},
+    {REFEREE_CHANNEL, {"referee", "192.168.1.33", "5557"}},
+    {WORLD_CHANNEL, {"world", "192.168.1.33", "5558"}},
+    {ROBOT_COMMANDS_PRIMARY_CHANNEL, {"commands_primary", "192.168.1.33", "5559"}},
+    {ROBOT_COMMANDS_SECONDARY_CHANNEL, {"commands_secondary", "192.168.1.33", "5560"}},
+    {FEEDBACK_PRIMARY_CHANNEL, {"feedback_primary", "192.168.1.33", "5561"}},
+    {FEEDBACK_SECONDARY_CHANNEL, {"feedback_yellow", "192.168.1.33", "5562"}},
+    {SETTINGS_PRIMARY_CHANNEL, {"settings_primary", "192.168.1.33", "5563"}},
+    {SETTINGS_SECONDARY_CHANNEL, {"settings_secondary", "192.168.1.33", "5564"}}
 };
 
 } // proto

--- a/src/Channels.cpp
+++ b/src/Channels.cpp
@@ -4,15 +4,15 @@
 namespace proto {
 
 const std::map<ChannelType, Channel> CHANNELS = {
-    {GEOMETRY_CHANNEL, {"geometry", "tcp://127.0.0.1:5556"}},
-    {REFEREE_CHANNEL, {"referee", "tcp://127.0.0.1:5557"}},
-    {WORLD_CHANNEL, {"world", "tcp://127.0.0.1:5558"}},
-    {ROBOT_COMMANDS_PRIMARY_CHANNEL, {"commands_primary", "tcp://127.0.0.1:5559"}},
-    {ROBOT_COMMANDS_SECONDARY_CHANNEL, {"commands_secondary", "tcp://127.0.0.1:5560"}},
-    {FEEDBACK_PRIMARY_CHANNEL, {"feedback_primary", "tcp://127.0.0.1:5561"}},
-    {FEEDBACK_SECONDARY_CHANNEL, {"feedback_yellow", "tcp://127.0.0.1:5562"}},
-    {SETTINGS_PRIMARY_CHANNEL, {"settings_primary", "tcp://127.0.0.1:5563"}},
-    {SETTINGS_SECONDARY_CHANNEL, {"settings_secondary", "tcp://127.0.0.1:5564"}}
+    {GEOMETRY_CHANNEL, {"geometry", "tcp://192.168.1.33:5556"}},
+    {REFEREE_CHANNEL, {"referee", "tcp://192.168.1.33:5557"}},
+    {WORLD_CHANNEL, {"world", "tcp://192.168.1.33:5558"}},
+    {ROBOT_COMMANDS_PRIMARY_CHANNEL, {"commands_primary", "tcp://192.168.1.33:5559"}},
+    {ROBOT_COMMANDS_SECONDARY_CHANNEL, {"commands_secondary", "tcp://192.168.1.33:5560"}},
+    {FEEDBACK_PRIMARY_CHANNEL, {"feedback_primary", "tcp://192.168.1.33:5561"}},
+    {FEEDBACK_SECONDARY_CHANNEL, {"feedback_yellow", "tcp://192.168.1.33:5562"}},
+    {SETTINGS_PRIMARY_CHANNEL, {"settings_primary", "tcp://192.168.1.33:5563"}},
+    {SETTINGS_SECONDARY_CHANNEL, {"settings_secondary", "tcp://192.168.1.33:5564"}}
 };
 
 } // proto

--- a/test/PubSubTest.cpp
+++ b/test/PubSubTest.cpp
@@ -43,7 +43,7 @@ TEST(PubSubTest, method_subscription) {
     int receivedTime = 0;
 
     Dummy() {
-      const proto::Channel DUMMY_CHANNEL = {"dummy_channel", "tcp://127.0.0.1:5555"};
+      const proto::Channel DUMMY_CHANNEL = {"dummy_channel", "127.0.0.1", "5555"};
       sub = std::make_shared<proto::Subscriber<proto::RobotCommand>>(proto::ROBOT_COMMANDS_PRIMARY_CHANNEL, &Dummy::handle_message, this);
     }
 


### PR DESCRIPTION
This PR changes some internal behaviors of roboteam_proto and adds functionality. It is now possible to give a custom ip address as parameter to a subscriber to subscribe to messages from another computer. I thought this would be a nice feature to have in combination with roboteam_monitor, since we could then monitor on a different device.  

The general functionality _should_ still work, but the publisher addresses did change. So, proceed with caution! 
