### PR TITLE
Added ER-Force simulator messages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,17 @@ protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS
         # New interface
         ${PROTO_BASE_PATH}/UiOptions.proto
         ${PROTO_BASE_PATH}/Handshake.proto
+
+        # SSL Simulation Protocol - Robocup 2021
+        ${PROTO_BASE_PATH}/ssl_gc_common.proto
+        ${PROTO_BASE_PATH}/ssl_simulation_config.proto
+        ${PROTO_BASE_PATH}/ssl_simulation_control.proto
+        ${PROTO_BASE_PATH}/ssl_simulation_error.proto
+        ${PROTO_BASE_PATH}/ssl_simulation_robot_control.proto
+        ${PROTO_BASE_PATH}/ssl_simulation_robot_feedback.proto
+        ${PROTO_BASE_PATH}/ssl_simulation_synchronous.proto
+        ${PROTO_BASE_PATH}/ssl_vision_detection.proto
+        ${PROTO_BASE_PATH}/ssl_vision_geometry.proto
         )
 
 add_library(roboteam_proto STATIC

--- a/proto/ssl_gc_common.proto
+++ b/proto/ssl_gc_common.proto
@@ -1,0 +1,27 @@
+syntax = "proto2";
+option go_package = "github.com/RoboCup-SSL/ssl-simulation-protocol/pkg/sim";
+
+// Team is either blue or yellow
+enum Team {
+    // team not set
+    UNKNOWN = 0;
+    // yellow team
+    YELLOW = 1;
+    // blue team
+    BLUE = 2;
+}
+
+// RobotId is the combination of a team and a robot id
+message RobotId {
+    // the robot number
+    optional uint32 id = 1;
+    // the team that the robot belongs to
+    optional Team team = 2;
+}
+
+// Division denotes the current division, which influences some rules
+enum Division {
+    DIV_UNKNOWN = 0;
+    DIV_A = 1;
+    DIV_B = 2;
+}

--- a/proto/ssl_simulation_config.proto
+++ b/proto/ssl_simulation_config.proto
@@ -1,0 +1,77 @@
+syntax = "proto2";
+option go_package = "github.com/RoboCup-SSL/ssl-simulation-protocol/pkg/sim";
+
+import "ssl_gc_common.proto";
+import "ssl_vision_geometry.proto";
+import "google/protobuf/any.proto";
+
+// Movement limits for a robot
+message RobotLimits {
+    // Max absolute speed-up acceleration [m/s^2]
+    optional float acc_speedup_absolute_max = 1;
+    // Max angular speed-up acceleration [rad/s^2]
+    optional float acc_speedup_angular_max = 2;
+    // Max absolute brake acceleration [m/s^2]
+    optional float acc_brake_absolute_max = 3;
+    // Max angular brake acceleration [rad/s^2]
+    optional float acc_brake_angular_max = 4;
+    // Max absolute velocity [m/s]
+    optional float vel_absolute_max = 5;
+    // Max angular velocity [rad/s]
+    optional float vel_angular_max = 6;
+}
+
+// Robot wheel angle configuration
+// all angles are relative to looking forward,
+// all wheels / angles are clockwise
+message RobotWheelAngles {
+    // Angle front right [rad]
+    required float front_right = 1;
+    // Angle back right [rad]
+    required float back_right = 2;
+    // Angle back left [rad]
+    required float back_left = 3;
+    // Angle front left [rad]
+    required float front_left = 4;
+}
+
+// Specs of a robot
+message RobotSpecs {
+    // Id of the robot
+    required RobotId id = 1;
+    // Robot radius [m]
+    optional float radius = 2 [default = 0.09];
+    // Robot height [m]
+    optional float height = 3 [default = 0.15];
+    // Robot mass [kg]
+    optional float mass = 4;
+    // Max linear kick speed [m/s] (unset = unlimited)
+    optional float max_linear_kick_speed = 7;
+    // Max chip kick speed [m/s] (unset = unlimited)
+    optional float max_chip_kick_speed = 8;
+    // Distance from robot center to dribbler [m] (implicitly defines the opening angle and dribbler width)
+    optional float center_to_dribbler = 9;
+    // Movement limits
+    optional RobotLimits limits = 10;
+    // Wheel angle configuration
+    optional RobotWheelAngles wheel_angles = 13;
+    // Custom robot spec for specific simulators (the protobuf files are managed by the simulators)
+    repeated google.protobuf.Any custom = 14;
+}
+
+message RealismConfig {
+    // Custom config for specific simulators (the protobuf files are managed by the simulators)
+    repeated google.protobuf.Any custom = 1;
+}
+
+// Change the simulator configuration
+message SimulatorConfig {
+    // Update the geometry
+    optional SSL_GeometryData geometry = 1;
+    // Update the robot specs
+    repeated RobotSpecs robot_specs = 2;
+    // Update realism configuration
+    optional RealismConfig realism_config = 3;
+    // Change the vision publish port
+    optional uint32 vision_port = 4;
+}

--- a/proto/ssl_simulation_control.proto
+++ b/proto/ssl_simulation_control.proto
@@ -1,0 +1,90 @@
+syntax = "proto2";
+option go_package = "github.com/RoboCup-SSL/ssl-simulation-protocol/pkg/sim";
+
+import "ssl_gc_common.proto";
+import "ssl_simulation_config.proto";
+import "ssl_simulation_error.proto";
+
+// Teleport the ball to a new location and optionally set it to some velocity
+message TeleportBall {
+    // x-coordinate [m]
+    optional float x = 1;
+    // y-coordinate [m]
+    optional float y = 2;
+    // z-coordinate (height) [m]
+    optional float z = 3;
+    // Velocity in x-direction [m/s]
+    optional float vx = 4;
+    // Velocity in y-direction [m/s]
+    optional float vy = 5;
+    // Velocity in z-direction [m/s]
+    optional float vz = 6;
+    // Teleport the ball safely to the target, for example by
+    // moving robots out of the way in case of collision and set speed of robots close-by to zero
+    optional bool teleport_safely = 7 [default = false];
+    // Adapt the angular ball velocity such that the ball is rolling
+    optional bool roll = 8 [default = false];
+    // Instead of teleporting the ball, apply some force to make sure
+    // the ball reaches the required position soon (velocity is ignored if true)
+    // WARNING: A command with by_force stays active (the move will take some time)
+    // until cancled by another TeleportBall command with by_force = false.
+    // To avoid teleporting the ball at the end and resetting its current spin,
+    // do not set any of the optional fields in this message to end the force without triggering
+    // an additional teleportation
+    optional bool by_force = 9 [ default = false];
+}
+
+// Teleport a robot to some location and give it a velocity
+message TeleportRobot {
+    // Robot id to teleport
+    required RobotId id = 1;
+    // x-coordinate [m]
+    optional float x = 2;
+    // y-coordinate [m]
+    optional float y = 3;
+    // Orientation [rad], measured from the x-axis counter-clockwise
+    optional float orientation = 4;
+    // Global velocity [m/s] towards x-axis
+    optional float v_x = 5 [default = 0];
+    // Global velocity [m/s] towards y-axis
+    optional float v_y = 6 [default = 0];
+    // Angular velocity [rad/s]
+    optional float v_angular = 7 [default = 0];
+    // Robot should be present on the field?
+    // true -> robot will be added, if it does not exist yet
+    // false -> robot will be removed, if it is present
+    optional bool present = 8;
+    // Instead of teleporting, apply some force to make sure
+    // the robot reaches the required position soon (velocity is ignored if true)
+    // WARNING: A command with by_force stays active (the move will take some time)
+    // until cancled by another TeleportRobot command for the same bot with by_force = false.
+    // To avoid teleporting at the end,
+    // do not set any of the optional fields in this message
+    // to end the force without triggering
+    // an additional teleportation
+    optional bool by_force = 9 [ default = false];
+}
+
+// Control the simulation
+message SimulatorControl {
+    // Teleport the ball
+    optional TeleportBall teleport_ball = 1;
+    // Teleport robots
+    repeated TeleportRobot teleport_robot = 2;
+    // Change the simulation speed
+    optional float simulation_speed = 3;
+}
+
+// Command from the connected client to the simulator
+message SimulatorCommand {
+    // Control the simulation
+    optional SimulatorControl control = 1;
+    // Configure the simulation
+    optional SimulatorConfig config = 2;
+}
+
+// Response of the simulator to the connected client
+message SimulatorResponse {
+    // List of errors, like using unsupported features
+    repeated SimulatorError errors = 1;
+}

--- a/proto/ssl_simulation_error.proto
+++ b/proto/ssl_simulation_error.proto
@@ -1,0 +1,10 @@
+syntax = "proto2";
+option go_package = "github.com/RoboCup-SSL/ssl-simulation-protocol/pkg/sim";
+
+// Errors in the simulator
+message SimulatorError {
+    // Unique code of the error for automatic handling on client side
+    optional string code = 1;
+    // Human readable description of the error
+    optional string message = 2;
+}

--- a/proto/ssl_simulation_robot_control.proto
+++ b/proto/ssl_simulation_robot_control.proto
@@ -1,0 +1,66 @@
+syntax = "proto2";
+option go_package = "github.com/RoboCup-SSL/ssl-simulation-protocol/pkg/sim";
+
+// Full command for a single robot
+message RobotCommand {
+    // Id of the robot
+    required uint32 id = 1;
+    // Movement command
+    optional RobotMoveCommand move_command = 2;
+    // Absolute (3 dimensional) kick speed [m/s]
+    optional float kick_speed = 3;
+    // Kick angle [degree] (defaults to 0 degrees for a straight kick)
+    optional float kick_angle = 4 [default = 0];
+    // Dribbler speed in rounds per minute [rpm]
+    optional float dribbler_speed = 5;
+}
+
+// Wrapper for different kinds of movement commands
+message RobotMoveCommand {
+    oneof command {
+        // Move with wheel velocities
+        MoveWheelVelocity wheel_velocity = 1;
+        // Move with local velocity
+        MoveLocalVelocity local_velocity = 2;
+        // Move with global velocity
+        MoveGlobalVelocity global_velocity = 3;
+    }
+}
+
+// Move robot with wheel velocities
+message MoveWheelVelocity {
+    // Velocity [m/s] of front right wheel
+    required float front_right = 1;
+    // Velocity [m/s] of back right wheel
+    required float back_right = 2;
+    // Velocity [m/s] of back left wheel
+    required float back_left = 3;
+    // Velocity [m/s] of front left wheel
+    required float front_left = 4;
+}
+
+// Move robot with local velocity
+message MoveLocalVelocity {
+    // Velocity forward [m/s] (towards the dribbler)
+    required float forward = 1;
+    // Velocity to the left [m/s]
+    required float left = 2;
+    // Angular velocity counter-clockwise [rad/s]
+    required float angular = 3;
+}
+
+// Move robot with global velocity
+message MoveGlobalVelocity {
+    // Velocity on x-axis of the field [m/s]
+    required float x = 1;
+    // Velocity on y-axis of the field [m/s]
+    required float y = 2;
+    // Angular velocity counter-clockwise [rad/s]
+    required float angular = 3;
+}
+
+// Command from the connected client to the simulator
+message RobotControl {
+    // Control the robots
+    repeated RobotCommand robot_commands = 1;
+}

--- a/proto/ssl_simulation_robot_feedback.proto
+++ b/proto/ssl_simulation_robot_feedback.proto
@@ -1,0 +1,23 @@
+syntax = "proto2";
+option go_package = "github.com/RoboCup-SSL/ssl-simulation-protocol/pkg/sim";
+
+import "ssl_simulation_error.proto";
+import "google/protobuf/any.proto";
+
+// Feedback from a robot
+message RobotFeedback {
+    // Id of the robot
+    required uint32 id = 1;
+    // Has the dribbler contact to the ball right now
+    optional bool dribbler_ball_contact = 2;
+    // Custom robot feedback for specific simulators (the protobuf files are managed by the simulators)
+    optional google.protobuf.Any custom = 3;
+}
+
+// Response to RobotControl from the simulator to the connected client
+message RobotControlResponse {
+    // List of errors, like using unsupported features
+    repeated SimulatorError errors = 1;
+    // Feedback of the robots
+    repeated RobotFeedback feedback = 2;
+}

--- a/proto/ssl_simulation_synchronous.proto
+++ b/proto/ssl_simulation_synchronous.proto
@@ -1,0 +1,25 @@
+syntax = "proto2";
+option go_package = "github.com/RoboCup-SSL/ssl-simulation-protocol/pkg/sim";
+
+import "ssl_vision_detection.proto";
+import "ssl_simulation_robot_feedback.proto";
+import "ssl_simulation_robot_control.proto";
+import "ssl_simulation_control.proto";
+
+// Request from the team to the simulator
+message SimulationSyncRequest {
+    // The simulation step [s] to perform
+    optional float sim_step = 1;
+    // An optional simulator command
+    optional SimulatorCommand simulator_command = 2;
+    // An optional robot control command
+    optional RobotControl robot_control = 3;
+}
+
+// Response to last SimulationSyncRequest
+message SimulationSyncResponse {
+    // List of detection frames for all cameras with the state after the simulation step in the request was performed
+    repeated SSL_DetectionFrame detection = 1;
+    // An optional robot control response
+    optional RobotControlResponse robot_control_response = 2;
+}

--- a/proto/ssl_vision_detection.proto
+++ b/proto/ssl_vision_detection.proto
@@ -1,0 +1,33 @@
+syntax = "proto2";
+option go_package = "github.com/RoboCup-SSL/ssl-simulation-protocol/pkg/sim";
+
+message SSL_DetectionBall {
+  required float  confidence = 1;
+  optional uint32 area       = 2;
+  required float  x          = 3;
+  required float  y          = 4;
+  optional float  z          = 5;
+  required float  pixel_x    = 6;
+  required float  pixel_y    = 7;
+}
+
+message SSL_DetectionRobot {
+  required float  confidence  =  1;
+  optional uint32 robot_id    =  2;
+  required float  x           =  3;
+  required float  y           =  4;
+  optional float  orientation =  5;
+  required float  pixel_x     =  6;
+  required float  pixel_y     =  7;
+  optional float  height      =  8;
+}
+
+message SSL_DetectionFrame {
+  required uint32             frame_number  = 1;
+  required double             t_capture     = 2;
+  required double             t_sent        = 3;
+  required uint32             camera_id     = 4;
+  repeated SSL_DetectionBall  balls         = 5;
+  repeated SSL_DetectionRobot robots_yellow = 6;
+  repeated SSL_DetectionRobot robots_blue   = 7;
+}

--- a/proto/ssl_vision_geometry.proto
+++ b/proto/ssl_vision_geometry.proto
@@ -1,0 +1,130 @@
+syntax = "proto2";
+option go_package = "github.com/RoboCup-SSL/ssl-simulation-protocol/pkg/sim";
+
+// A 2D float vector.
+message Vector2f {
+  required float x = 1;
+  required float y = 2;
+}
+
+// Represents a field marking as a line segment represented by a start point p1,
+// and end point p2, and a line thickness. The start and end points are along
+// the center of the line, so the thickness of the line extends by thickness / 2
+// on either side of the line.
+message SSL_FieldLineSegment {
+  // Name of this field marking.
+  required string name = 1;
+  // Start point of the line segment.
+  required Vector2f p1 = 2;
+  // End point of the line segment.
+  required Vector2f p2 = 3;
+  // Thickness of the line segment.
+  required float thickness = 4;
+  // The type of this shape
+  optional SSL_FieldShapeType type = 5;
+}
+
+// Represents a field marking as a circular arc segment represented by center point, a
+// start angle, an end angle, and an arc thickness.
+message SSL_FieldCircularArc {
+  // Name of this field marking.
+  required string name = 1;
+  // Center point of the circular arc.
+  required Vector2f center = 2;
+  // Radius of the arc.
+  required float radius = 3;
+  // Start angle in counter-clockwise order.
+  required float a1 = 4;
+  // End angle in counter-clockwise order.
+  required float a2 = 5;
+  // Thickness of the arc.
+  required float thickness = 6;
+  // The type of this shape
+  optional SSL_FieldShapeType type = 7;
+}
+
+message SSL_GeometryFieldSize {
+  required int32 field_length = 1;
+  required int32 field_width = 2;
+  required int32 goal_width = 3;
+  required int32 goal_depth = 4;
+  required int32 boundary_width = 5;
+  repeated SSL_FieldLineSegment field_lines = 6;
+  repeated SSL_FieldCircularArc field_arcs = 7;
+  optional int32 penalty_area_depth = 8;
+  optional int32 penalty_area_width = 9;
+}
+
+message SSL_GeometryCameraCalibration {
+  required uint32 camera_id     = 1;
+  required float focal_length = 2;
+  required float principal_point_x = 3;
+  required float principal_point_y = 4;
+  required float distortion = 5;
+  required float q0 = 6;
+  required float q1 = 7;
+  required float q2 = 8;
+  required float q3 = 9;
+  required float tx = 10;
+  required float ty = 11;
+  required float tz = 12;
+  optional float derived_camera_world_tx = 13;
+  optional float derived_camera_world_ty = 14;
+  optional float derived_camera_world_tz = 15;
+  optional uint32 pixel_image_width = 16;
+  optional uint32 pixel_image_height = 17;
+}
+
+// Two-Phase model for straight-kicked balls.
+// There are two phases with different accelerations during the ball kicks:
+// 1. Sliding
+// 2. Rolling
+// The full model is described in the TDP of ER-Force from 2016, which can be found here:
+// https://ssl.robocup.org/wp-content/uploads/2019/01/2016_ETDP_ER-Force.pdf
+message SSL_BallModelStraightTwoPhase {
+  // Ball sliding acceleration [m/s^2] (should be negative)
+  required double acc_slide = 1;
+  // Ball rolling acceleration [m/s^2] (should be negative)
+  required double acc_roll = 2;
+  // Fraction of the initial velocity where the ball starts to roll
+  required double k_switch = 3;
+}
+
+// Fixed-Loss model for chipped balls.
+// Uses fixed damping factors for xy and z direction per hop.
+message SSL_BallModelChipFixedLoss {
+  // Chip kick velocity damping factor in XY direction for the first hop
+  required double damping_xy_first_hop = 1;
+  // Chip kick velocity damping factor in XY direction for all following hops
+  required double damping_xy_other_hops = 2;
+  // Chip kick velocity damping factor in Z direction for all hops
+  required double damping_z = 3;
+}
+
+message SSL_GeometryModels {
+  optional SSL_BallModelStraightTwoPhase straight_two_phase = 1;
+  optional SSL_BallModelChipFixedLoss chip_fixed_loss = 2;
+}
+
+message SSL_GeometryData {
+  required SSL_GeometryFieldSize field = 1;
+  repeated SSL_GeometryCameraCalibration calib = 2;
+  optional SSL_GeometryModels models = 3;
+}
+
+enum SSL_FieldShapeType {
+  Undefined = 0;
+  CenterCircle = 1;
+  TopTouchLine = 2;
+  BottomTouchLine = 3;
+  LeftGoalLine = 4;
+  RightGoalLine = 5;
+  HalfwayLine = 6;
+  CenterLine = 7;
+  LeftPenaltyStretch = 8;
+  RightPenaltyStretch = 9;
+  LeftFieldLeftPenaltyStretch = 10;
+  LeftFieldRightPenaltyStretch = 11;
+  RightFieldLeftPenaltyStretch = 12;
+  RightFieldRightPenaltyStretch = 13;
+}


### PR DESCRIPTION
Added the ER-Force simulator protobuf messages to roboteam_proto, as preparation for the upcoming robocup. Original messages can be found here [https://github.com/RoboCup-SSL/ssl-simulation-protocol](https://github.com/RoboCup-SSL/ssl-simulation-protocol)

```
Dear teams,

the deadline for choosing the simulator to be used has approached. Unfortunately, there was not much feedback from teams so far.
Two teams said they prefer grSim, two prefer the ER-Force simulator.

The TC decided to go with the ER-Force simulator, because it is more realistic and more stable. 
The simulator ships with a "RC2021" realism config that we will use.
We will still keep grSim as the backup-option, in case there are serious issues with the ER-Force simulator during the tournament.

The ssl-simulation-setup repository already uses the ER-Force Simulator by default.

Regards,
Nicolai
RoboCup Small Size League | Technical Committee
```