### PR TITLE
MacOS support and build improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,5 @@
+cmake_minimum_required(VERSION 3.16)
+
 set(PROTO_BASE_PATH proto)
 
 find_package(Protobuf 3.9.1 REQUIRED)
@@ -78,3 +80,5 @@ target_include_directories(roboteam_proto
         # This points to cmake-build-debug/proto/include/proto
         PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/..
         )
+
+set_target_properties(roboteam_proto PROPERTIES UNITY_BUILD FALSE)


### PR DESCRIPTION
This was supposed to be just a quick job of adding MacOS support, but I noticed a couple of things that could be improved with the build system.

- Refactor to use modern CMake
- Work around Qt5 issues on MacOS
- Add instructions on how to build on MacOS
- Add missing and remove redundant dependencies in README
- Add CCache install instructions to README
- Set CMake to use unity builds
- Remove unused CMake files (cotire was included but not actually used)
  - Use modern CMake features to speed up build times
- Recommend and set default build system to Ninja
- Use newer method of fetching/discovering dependencies
   - Remove unnecessary third party git submodules 
- Change structure of some roboteam repositories (e.g. where full CMake projects were nested in the `include/` directory)


Only meant to be merged together with corresponding PRs in other repos.